### PR TITLE
semicolon causing style dint apply properly

### DIFF
--- a/dog/app.js
+++ b/dog/app.js
@@ -122,7 +122,7 @@ function init() {
   const setStyles = ({ target, h, w, x, y }) =>{
     if (h) target.style.height = h
     if (w) target.style.width = w
-    target.style.transform = `translate(${x || 0}, ${y || 0});`
+    target.style.transform = `translate(${x || 0}, ${y || 0})`
   }
 
   const targetAngle = dog =>{


### PR DESCRIPTION
Hi !,this is a really cute project, i was working on make it into my desktop wallpaper but realize dog leg and tail aren't on the correct position, causing him look like a duck lol, Here's an example:
![dog](https://github.com/masarabbit/interactive_animals/assets/48248414/eaa28c9f-cbae-4510-831f-ab6166e4ec5c)
the extra semicolon seems to be the culprit so submitted a pull request to address this minor bug.